### PR TITLE
Allow  kernel to boot straight to recovery, disables dm-verify and FEC and adds missing files

### DIFF
--- a/drivers/md/dm-android-verity.c
+++ b/drivers/md/dm-android-verity.c
@@ -370,7 +370,7 @@ static int find_size(dev_t dev, u64 *device_size)
 static int verify_header(struct android_metadata_header *header)
 {
 	int retval = -EINVAL;
-
+	return VERITY_STATE_DISABLE;
 	if (is_userdebug() && le32_to_cpu(header->magic_number) ==
 			VERITY_METADATA_MAGIC_DISABLE)
 		return VERITY_STATE_DISABLE;

--- a/init/initramfs.c
+++ b/init/initramfs.c
@@ -282,14 +282,14 @@ static int __init do_header(void)
 
 static int __init do_skip(void)
 {
-	/* if (this_header + byte_count < next_header) {
+	if (this_header + byte_count < next_header) {
 		eat(byte_count);
 		return 1;
 	} else {
 		eat(next_header - this_header);
 		state = next_state;
 		return 0;
-	}*/
+	}
 	return 0;
 }
 
@@ -623,8 +623,8 @@ static int __init populate_rootfs(void)
 {
 	char *err;
 
-	if (do_skip_initramfs)
-		return default_rootfs();
+	/*if (do_skip_initramfs)
+		return default_rootfs();*/
 
 	err = unpack_to_rootfs(__initramfs_start, __initramfs_size);
 	if (err)

--- a/init/initramfs.c
+++ b/init/initramfs.c
@@ -282,14 +282,15 @@ static int __init do_header(void)
 
 static int __init do_skip(void)
 {
-	if (this_header + byte_count < next_header) {
+	/* if (this_header + byte_count < next_header) {
 		eat(byte_count);
 		return 1;
 	} else {
 		eat(next_header - this_header);
 		state = next_state;
 		return 0;
-	}
+	}*/
+	return 0;
 }
 
 static int __init do_reset(void)

--- a/techpack/Kbuild
+++ b/techpack/Kbuild
@@ -1,0 +1,5 @@
+techpack-dirs := $(shell find $(srctree)/$(src) -maxdepth 1 -mindepth 1 -type d -not -name ".*")
+obj-y += stub/ $(addsuffix /,$(subst $(srctree)/$(src)/,,$(techpack-dirs)))
+
+techpack-header-dirs := $(shell find $(srctree)/techpack -maxdepth 1 -mindepth 1 -type d -not -name ".*")
+header-y += $(addsuffix /include/uapi/,$(subst $(srctree)/techpack/,,$(techpack-header-dirs)))

--- a/techpack/stub/Makefile
+++ b/techpack/stub/Makefile
@@ -1,0 +1,2 @@
+ccflags-y := -Wno-unused-function
+obj-y := stub.o

--- a/techpack/stub/include/uapi/Kbuild
+++ b/techpack/stub/include/uapi/Kbuild
@@ -1,0 +1,1 @@
+#Stub place holder

--- a/techpack/stub/stub.c
+++ b/techpack/stub/stub.c
@@ -1,0 +1,3 @@
+static void _techpack_stub(void)
+{
+}


### PR DESCRIPTION
This allows the kernel to boot straight into recovery (vs. having to start recovery from the bootloader) and also disables dm-verify and FEC.

Also, got a weird techpack error in the compiler right after I forked your repo.  I believe that maybe you just didn't add it to your repo? Lemme know if that's right.

Also just FYI, this kernel still doesn't seem to boot into recovery.  Looks like it hangs in fastboot (I can still interrogate the device via fastboot even though it "looks" frozen/hung"